### PR TITLE
PDF を生成するコマンドを実行する Visual Studio Code ビルドタスクを追加しました。

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build PDF with Re:View",
+            "type": "shell",
+            "command": "review",
+            "args": [
+                "pdfmaker",
+                "config.yml"
+            ],
+            "options": {
+                "cwd": "articles"
+            },
+            "group": "build",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build PDF with Re:View",
+            "label": "Build PDF with Re:VIEW",
             "type": "shell",
             "command": "review",
             "args": [


### PR DESCRIPTION
Visual Studio Code で `Onestop-meeting` フォルダーを開いた時に、ビルドタスク `Build PDF with Re:VIEW` を実行することで Re:VIEW コマンドを直接実行して PDF 生成を行えるようにしました。

> Docker 環境を使っての PDF 生成ビルドタスクは、今は用意していません。